### PR TITLE
Added  to the models' configs to prevent pytest from creating  in the…

### DIFF
--- a/tests/pipeline/nodes/model/csrnetv1/test_csrnet.py
+++ b/tests/pipeline/nodes/model/csrnetv1/test_csrnet.py
@@ -44,8 +44,10 @@ def csrnet_config(request):
     with open(PKD_DIR / "configs" / "model" / "csrnet.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     node_config["model_type"] = request.param
-
     return node_config
 
 

--- a/tests/pipeline/nodes/model/efficientdet_d04/test_efficientdet.py
+++ b/tests/pipeline/nodes/model/efficientdet_d04/test_efficientdet.py
@@ -47,7 +47,9 @@ def efficientdet_config():
     with open(PKD_DIR / "configs" / "model" / "efficientdet.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
@@ -56,7 +56,9 @@ def fairmot_config():
     with open(PKD_DIR / "configs" / "model" / "fairmot.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     with mock.patch("torch.cuda.is_available", return_value=False):
         yield node_config
 

--- a/tests/pipeline/nodes/model/hrnetv1/test_hrnet.py
+++ b/tests/pipeline/nodes/model/hrnetv1/test_hrnet.py
@@ -47,7 +47,9 @@ def hrnet_config():
     with open(PKD_DIR / "configs" / "model" / "hrnet.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/jdev1/test_jde.py
+++ b/tests/pipeline/nodes/model/jdev1/test_jde.py
@@ -56,7 +56,9 @@ def jde_config():
     with open(PKD_DIR / "configs" / "model" / "jde.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     with mock.patch("torch.cuda.is_available", return_value=False):
         yield node_config
 

--- a/tests/pipeline/nodes/model/mask_rcnnv1/test_mask_rcnn.py
+++ b/tests/pipeline/nodes/model/mask_rcnnv1/test_mask_rcnn.py
@@ -51,10 +51,12 @@ def mask_rcnn_config():
     with open(PKD_DIR / "configs" / "model" / "mask_rcnn.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     node_config["iou_threshold"] = 0.5
     node_config["score_threshold"] = 0.5
     node_config["mask_threshold"] = 0.5
-
     return node_config
 
 

--- a/tests/pipeline/nodes/model/movenetv1/test_movenet.py
+++ b/tests/pipeline/nodes/model/movenetv1/test_movenet.py
@@ -47,7 +47,9 @@ def movenet_config():
     with open(PKD_DIR / "configs" / "model" / "movenet.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/mtcnnv1/test_mtcnn.py
+++ b/tests/pipeline/nodes/model/mtcnnv1/test_mtcnn.py
@@ -49,7 +49,9 @@ def mtcnn_config():
     with open(PKD_DIR / "configs" / "model" / "mtcnn.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/posenetv1/test_posenet.py
+++ b/tests/pipeline/nodes/model/posenetv1/test_posenet.py
@@ -49,6 +49,9 @@ def posenet_config():
     with open(PKD_DIR / "configs" / "model" / "posenet.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/rt_detrv1/test_rt_detr.py
+++ b/tests/pipeline/nodes/model/rt_detrv1/test_rt_detr.py
@@ -34,8 +34,10 @@ GT_RESULTS = get_groundtruth(Path(__file__).resolve())
 def rt_detr_config():
     with open(PKD_DIR / "configs" / "model" / "rt_detr.yml") as infile:
         node_config = yaml.safe_load(infile)
-    
     node_config["root"] = Path.cwd()
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/yolact_edgev1/test_yolact_edge.py
+++ b/tests/pipeline/nodes/model/yolact_edgev1/test_yolact_edge.py
@@ -50,6 +50,9 @@ def yolact_edge_config():
     with open(PKD_DIR / "configs" / "model" / "yolact_edge.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     node_config["score_threshold"] = 0.2
     return node_config
 

--- a/tests/pipeline/nodes/model/yolov4/test_yolo.py
+++ b/tests/pipeline/nodes/model/yolov4/test_yolo.py
@@ -49,7 +49,9 @@ def yolo_config():
     with open(PKD_DIR / "configs" / "model" / "yolo.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
+++ b/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
@@ -47,7 +47,9 @@ def yolo_config():
     with open(PKD_DIR / "configs" / "model" / "yolo_face.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/yolov4_license_plate/test_yolov4_license_plate.py
+++ b/tests/pipeline/nodes/model/yolov4_license_plate/test_yolov4_license_plate.py
@@ -46,7 +46,9 @@ def yolo_config():
     with open(PKD_DIR / "configs" / "model" / "yolo_license_plate.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     return node_config
 
 

--- a/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
+++ b/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
@@ -50,6 +50,9 @@ def yolox_config():
     with open(PKD_DIR / "configs" / "model" / "yolox.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
+    # The following prevents pytest from creating `peekingduck_weights/`
+    # in the parent directory of `PeekingDuckReborn/`.
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     # The original input size for YOLOX is 512, however the authors of 
     # PeekingDuck use 416 as the default. Although in PeekingDuckReborn we have
     # reset the value to 512, for tests 416 is required for the correct results.


### PR DESCRIPTION
… wrong location.

c.f. line 321 in `peekingduck/pipeline/nodes/base.py`:
```python        
if self.config["weights_parent_dir"] is None:
    weights_parent_dir = self.config["root"].parent
else:
    weights_parent_dir = Path(self.config["weights_parent_dir"])
```
If `weights_parent_dir` is not set, `root.parent` will be used. During tests `root` is set as `PeekingDuckReborn/`, therefore the weights will be saved to `PeekingDuckReborn/.parent` in the wrong place.