### PR TITLE
Patched issue where peekingduck_weights/ is created above PeekingDuck…

### DIFF
--- a/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
@@ -72,7 +72,7 @@ def fairmot_config_gpu():
     with open(PKD_DIR / "configs" / "model" / "fairmot.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     yield node_config
 
 

--- a/tests/pipeline/nodes/model/jdev1/test_jde.py
+++ b/tests/pipeline/nodes/model/jdev1/test_jde.py
@@ -71,7 +71,7 @@ def jde_config_gpu():
     with open(PKD_DIR / "configs" / "model" / "jde.yml") as infile:
         node_config = yaml.safe_load(infile)
     node_config["root"] = Path.cwd()
-
+    node_config["weights_parent_dir"] = str(PKD_DIR.parent)
     yield node_config
 
 


### PR DESCRIPTION
…Reborn/. This was due to an issue with the original implementation of the tests. Fixed tests now create/use peekingduck_weights/ under PeekingDuckReborn/.