### PR TITLE
Updated rt-detr inputs from PIL Image to torch tensors on CUDA for sp…

### DIFF
--- a/peekingduck/pipeline/nodes/model/rt_detrv1/rt_detr_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/rt_detrv1/rt_detr_files/detector.py
@@ -111,13 +111,11 @@ class Detector:  # pylint: disable=too-many-instance-attributes
 
 
     def preprocess(self, image, return_tensors="pt"):
-        # HuggingFace image processors take in PIL images typically...
-        image = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
-        inputs = self.image_processor(
-            images=image, return_tensors=return_tensors, # device=self.device,
-        )
-        inputs = inputs.to(self.device)
-        return inputs
+        # RT-DETR image processor takes images as RGB.
+        # To tensor on CUDA for faster preprocessing.
+        images = torch.from_numpy(cv2.cvtColor(image, cv2.COLOR_BGR2RGB)).to(self.device)
+        inputs = self.image_processor(images=images, return_tensors=return_tensors)
+        return inputs.to(self.device)
     
 
     def postprocess(self, predictions, image_shape):


### PR DESCRIPTION
…eedup.

Although the HuggingFace image processor can take PIL Images as input, this requires converting the data in PKDR's pipeline from numpy ndarrays to PIL Images which consumes additional resources. Also, the PIL Images are converted to torch Tensors eventually. Therefore it makes more sense to convert directly from numpy ndarray to torch Tensor on CUDA to speed up the image processing process.

https://huggingface.co/docs/transformers/en/model_doc/rt_detr#transformers.RTDetrImageProcessor.preprocess